### PR TITLE
use stdint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The C-based decoder function doesn't have the same functionality, but it will as
 
 Just `#include "bg80d.h"`, and then call `decode()` with a function pointer that reads and returns bytes, a `void *` for context for your function, and an `int` for the current PC (not critical, can be 0).  It will return an `opcode_spec` structure that has information about how that opcode was decoded (see bg80d.h for fields).
 
-The function you pass in must have the signature `__uint8_t myfunc(void *)`.  `decode()` will use this function, calling it with the supplied `void *`,  to obtain a stream of bytes as needed to determine prefix and nn/n/d/dn parameters.
+The function you pass in must have the signature `uint8_t myfunc(void *)`.  `decode()` will use this function, calling it with the supplied `void *`,  to obtain a stream of bytes as needed to determine prefix and nn/n/d/dn parameters.
 
 If you pass in PC, it will include the post-decoded PC in `opcode_spec->pc_after` (if you pass in 0, you'll simply get the number of bytes read).  It will also use the supplied PC to compute relative jumps for `opcode_spec->description`.
 
@@ -55,12 +55,12 @@ Example program:
 ```c
 #include "bg80d.h"
 
-__uint8_t rom[17] = {0xf3, 0x3e, 0x3f, 0xed, 0x47, 0xc3, 0x0b, 0x23, 0x77, 0x23, 0x10, 0xFC, 0xc9, 0xc3, 0x0e, 0x07, 0x00};
+uint8_t rom[17] = {0xf3, 0x3e, 0x3f, 0xed, 0x47, 0xc3, 0x0b, 0x23, 0x77, 0x23, 0x10, 0xFC, 0xc9, 0xc3, 0x0e, 0x07, 0x00};
 
 int addr = 0;
 
-__uint8_t romread(void * ctx) {
-    __uint8_t rval = rom[*(int *)ctx];
+uint8_t romread(void * ctx) {
+    uint8_t rval = rom[*(int *)ctx];
     (*((int *)ctx))++;
     return rval;
 }

--- a/bg80d.h
+++ b/bg80d.h
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 namespace bg80d {
@@ -13,19 +14,19 @@ namespace bg80d {
 
 typedef struct {
     const char * prefix;
-    __uint8_t opcode;
-    __int8_t extra_num;
-    __int8_t extra_type;  // nn, n, d, or d/n
+    uint8_t opcode;
+    int8_t extra_num;
+    int8_t extra_type;  // nn, n, d, or d/n
     const char * type;
     const char * dst;
     const char * src;
     const char * mnemonic;
     const char * summary;
     char description[120];
-    __int16_t parameter1;
-    __int8_t parameter2;
-    __uint16_t pc_after;
-    __uint16_t jump_addr;
+    int16_t parameter1;
+    int8_t parameter2;
+    uint16_t pc_after;
+    uint16_t jump_addr;
 } opcode_spec_t;
 
 static opcode_spec_t z80_NP[] = {
@@ -1836,13 +1837,13 @@ static opcode_spec_t z80_FDCB[] = {
 };
 
 
-opcode_spec_t * decode(__uint8_t (*reader)(void *), void * ctx, int PC)
+opcode_spec_t * decode(uint8_t (*reader)(void *), void * ctx, int PC)
 {
     static opcode_spec_t opcode;
     opcode_spec_t * opcode_bank;
-    __uint16_t bytes_read = 0;
+    uint16_t bytes_read = 0;
     char buffer[9];
-    __uint8_t z80byte;
+    uint8_t z80byte;
 
     opcode_bank = z80_NP;
     while(z80byte = reader(ctx), bytes_read++, ((z80byte == 0xCB) || (z80byte == 0xDD) || (z80byte == 0xED) || (z80byte == 0xFD))) {


### PR DESCRIPTION
Use `uint...` and `int...` types instead of `__uint...` and `__int...` and include `stdint.h`.  This allows Emscripten to compile `bg80d.h`.  Tested against test program embedded in `README.md`.